### PR TITLE
Fix dupe on sort under certain circumstances

### DIFF
--- a/src/main/java/com/cleanroommc/bogosorter/common/sort/SortHandler.java
+++ b/src/main/java/com/cleanroommc/bogosorter/common/sort/SortHandler.java
@@ -98,13 +98,14 @@ public class SortHandler {
                     slot.putStack(ItemStack.EMPTY);
                     continue;
                 }
-                if (!itemSortContainer.canMakeStack()) {
-                    itemSortContainer = itemList.pollFirst();
-                    if (itemSortContainer == null) continue;
-                }
+
                 int max = slot.getItemStackLimit(itemSortContainer.getItemStack());
                 if (max <= 0) continue;
                 slot.putStack(itemSortContainer.makeStack(max));
+
+                if (!itemSortContainer.canMakeStack()) {
+                    itemSortContainer = itemList.pollFirst();
+                }
             }
         }
         if (!itemList.isEmpty()) {


### PR DESCRIPTION
When a item was in the second slot and you hit sort, it would duplicate to the first slot.
Thanks to @Caedis for fixing this