### PR TITLE
Arcane archive support

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -86,4 +86,5 @@ dependencies {
     compileOnly rfg.deobf("curse.maven:industrial-renewal-299849:3340876")
     compileOnly rfg.deobf("curse.maven:rftools-224641:2861573")
     compileOnly rfg.deobf("curse.maven:mcjtylib-233105:2745846")
+    compileOnly rfg.deobf("curse.maven:arcane-archives-311357:3057332")
 }

--- a/src/main/java/com/cleanroommc/bogosorter/compat/DefaultCompat.java
+++ b/src/main/java/com/cleanroommc/bogosorter/compat/DefaultCompat.java
@@ -5,6 +5,9 @@ import blusunrize.immersiveengineering.common.gui.ContainerCrate;
 import c4.conarm.common.inventory.ContainerKnapsack;
 import cassiokf.industrialrenewal.gui.container.ContainerStorageChest;
 import codechicken.enderstorage.container.ContainerEnderItemStorage;
+import com.aranaira.arcanearchives.config.ConfigHandler;
+import com.aranaira.arcanearchives.inventory.ContainerRadiantChest;
+import com.aranaira.arcanearchives.inventory.slots.SlotExtended;
 import com.brandon3055.draconicevolution.inventory.ContainerDraconiumChest;
 import com.cleanroommc.bogosorter.BogoSorter;
 import com.cleanroommc.bogosorter.ShortcutHandler;
@@ -462,6 +465,21 @@ public class DefaultCompat {
 
         if (Loader.isModLoaded("conarm")) {
             api.addGenericCompat(ContainerKnapsack.class);
+        }
+
+        if (Loader.isModLoaded("arcanearchives")) {
+            api.addCompat(ContainerRadiantChest.class, (chest, builder) -> {
+                var slots = new ArrayList<ISlot>();
+                for (Slot slot : chest.inventorySlots) {
+                    if (slot instanceof SlotExtended) {
+                        /**
+                         * @see com.aranaira.arcanearchives.inventory.handlers.ExtendedItemStackHandler#getSlotLimit(int)
+                         */
+                        slots.add(new FixedLimitSlot(slot, 64 * ConfigHandler.serverSideConfig.RadiantMultiplier));
+                    }
+                }
+                builder.addSlotGroup(slots, 9);
+            });
         }
     }
 

--- a/src/main/java/com/cleanroommc/bogosorter/compat/FixedLimitSlot.java
+++ b/src/main/java/com/cleanroommc/bogosorter/compat/FixedLimitSlot.java
@@ -1,0 +1,32 @@
+package com.cleanroommc.bogosorter.compat;
+
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
+
+/**
+ * @author ZZZank
+ */
+public class FixedLimitSlot extends SlotDelegate {
+    private final int sizeLimit;
+
+    public FixedLimitSlot(Slot slot, int sizeLimit) {
+        super(slot);
+        if (sizeLimit <= 0) {
+            throw new IllegalArgumentException(String.format(
+                "size limit '%s' not valid, must be positive number",
+                sizeLimit
+            ));
+        }
+        this.sizeLimit = sizeLimit;
+    }
+
+    @Override
+    public int bogo$getItemStackLimit(ItemStack itemStack) {
+        return sizeLimit;
+    }
+
+    @Override
+    public int bogo$getMaxStackSize(ItemStack itemStack) {
+        return sizeLimit;
+    }
+}

--- a/src/main/java/com/cleanroommc/bogosorter/compat/InfinitySlotWrapper.java
+++ b/src/main/java/com/cleanroommc/bogosorter/compat/InfinitySlotWrapper.java
@@ -6,12 +6,12 @@ import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import wanion.avaritiaddons.block.chest.infinity.InfinitySlot;
 
-public class InfinitySlotWrapper extends SlotDelegate {
+public class InfinitySlotWrapper extends FixedLimitSlot {
 
     public final InfinitySlot infinitySlot;
 
     public InfinitySlotWrapper(InfinitySlot slot) {
-        super(slot);
+        super(slot, Integer.MAX_VALUE);
         this.infinitySlot = slot;
     }
 
@@ -24,16 +24,6 @@ public class InfinitySlotWrapper extends SlotDelegate {
     @Override
     public @NotNull ItemStack bogo$getStack() {
         return this.infinitySlot.getInfinityMatching().getStack();
-    }
-
-    @Override
-    public int bogo$getMaxStackSize(ItemStack itemStack) {
-        return Integer.MAX_VALUE;
-    }
-
-    @Override
-    public int bogo$getItemStackLimit(@NotNull ItemStack stack) {
-        return Integer.MAX_VALUE;
     }
 
     @Override


### PR DESCRIPTION
This PR:
- adds a new slot wrapper type: `FixedLimitSlot` that allows customizing how bogo determine stack limit of a slot
- adds support for Radiant Chest from Arcane Archives

Testing:
before sorting:
<img width="500" alt="before" src="https://github.com/user-attachments/assets/f5ee9644-1e62-4157-bd64-5e1e049cc242">

after sorting:
<img width="500" alt="after" src="https://github.com/user-attachments/assets/283ddb97-1331-4526-8453-6999de71f23d">
