### PR TITLE
Replace Jabel with JVMDowngrader

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -766,16 +766,18 @@ jar {
 }
 
 if (enableModernJavaSyntax.toBoolean()) {
-    // downgrade code runClient/runServer/build
-    shadeDowngradedApi {
-        archiveClassifier = "dev" // debug session will use the "-dev" jar
-    }
-    jar {
-        archiveClassifier = "dev-undowngraded"
-        finalizedBy(shadeDowngradedApi)
-    }
+    // downgrade code for build
     tasks.named('reobfJar', ReobfuscatedJar) {
         inputJar.set((shadeDowngradedApi as Jar).archiveFile)
+        dependsOn(shadeDowngradedApi)
+    }
+    // downgrade code for runClient/runServer
+    // modern run task, e.g. runClient17, are left as-is, to allow dev to test raw (before downgrading) logic
+    for (runTask in ['runClient', 'runServer']) {
+        tasks.named(runTask, RunMinecraftTask) {
+            classpath = classpath - layout.files(jar) + layout.files(shadeDowngradedApi)
+            dependsOn(shadeDowngradedApi)
+        }
     }
 }
 


### PR DESCRIPTION
JVMDowngrader provides more feature than Jabel. In addition to modern Java syntax support, JVMDwongrader (JVMDG) will also allow us to use members introduced on modern Java version, e.g. `List.of()` and `"someStr".lines()`.

This buildscript natively supports running client/server on Java 17 and Java 21, but for the sake of testing, I made some extra effort to apply JVMDG to normal `runClient` and `runServer` task, allowing you to test Java 8 compatibility without having to build jar and test in production environment.

I made some tests, and can confirm `build`/`runClient`/`runServer` is working for me.

## Example for `build`:

`Example.java` in source file:
```java
import java.util.ArrayList;
import java.util.List;

public class Example {
    public static void main(String[] args) {
        var j11lines = "wowww".lines();
        if (List.of() instanceof ArrayList<Object> arrayList) {
            arrayList.addAll(j11lines.toList());
        }
    }
}
```

`Example.class` in built jar (`bogosorter-1.4.11.jar`):
```java
import bogosorter.xyz.wagyourtail.jvmdg.j16.stub.java_base.J_U_S_Stream;
import java.io.BufferedReader;
import java.io.StringReader;
import java.util.ArrayList;
import java.util.Collections;
import java.util.List;
import java.util.stream.Stream;
import xyz.wagyourtail.jvmdg.version.Ref;
import xyz.wagyourtail.jvmdg.version.Stub;

public class Example {
    public static void main(String[] args) {
        Stream<String> j11lines = jvmdg$inlined$lines("wowww");
        List var3 = jvmdg$inlined$of();
        if (var3 instanceof ArrayList) {
            ArrayList<Object> arrayList = (ArrayList)var3;
            arrayList.addAll(J_U_S_Stream.toList(j11lines));
        }
    }

    // $FF: synthetic method
    @Stub(ref = @Ref("Ljava/util/List;"))
    private static <E> List<E> jvmdg$inlined$of() {
        return Collections.emptyList();
    }

    // $FF: synthetic method
    @Stub
    private static Stream<String> jvmdg$inlined$lines(String str) {
        return (new BufferedReader(new StringReader(str))).lines();
    }
}
```
You can ignore the `@Ref` and `@Stub` annotation, they are invisible at runtime