### PR TITLE
Fix Detection of GTCE TJ Fork

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -109,4 +109,8 @@ dependencies {
     // To test against GTCEu, uncomment this block
 //    runtimeOnly "codechicken:codechickenlib:3.2.3.358"
 //    runtimeOnly rfg.deobf('curse.maven:gregtech_ce_unofficial-557242:4325257')
+
+    // To test against GT TJ Fork, uncomment this block
+//    runtimeOnly "codechicken:codechickenlib:3.2.3.358"
+//    runtimeOnly rfg.deobf('curse.maven:gtce_tj_edition-597032:8244866')
 }

--- a/src/main/java/com/cleanroommc/bogosorter/BogoSorter.java
+++ b/src/main/java/com/cleanroommc/bogosorter/BogoSorter.java
@@ -116,6 +116,7 @@ public class BogoSorter {
         GTCE(ModIds.GREGTECH, GTCompat::isGTCE),
         GTNE(ModIds.GREGTECH, GTCompat::isGTNE),
         GTCEu(ModIds.GREGTECH, GTCompat::isGTCEu),
+        GTTJ(ModIds.GREGTECH, GTCompat::isGTTJ),
 
         IC2_ANY(ModIds.IC2),
         IC2_CLASSIC(ModIds.IC2, m -> m.getName().endsWith("Classic")),

--- a/src/main/java/com/cleanroommc/bogosorter/compat/gtce/GTCompat.java
+++ b/src/main/java/com/cleanroommc/bogosorter/compat/gtce/GTCompat.java
@@ -31,13 +31,14 @@ public class GTCompat {
     private static final GT GTNE  = new GT("GregTech Nomifactory Edition");
     /** GregTech Community Edition Unofficial */
     private static final GT GTCEu = new GT("GregTech", "gregtech.api.items.toolitem.IGTTool", "GT.Tool");
+    /** GregTech Tech Journey Fork */
+    private static final GT GTTJ  = new GT("GregTech CE TJ");
 
     static {
-        // All three GregTechs use the ModID "gregtech"
+        // All four GregTechs use the ModID "gregtech"
         BogoSorter.Mods mod = BogoSorter.Mods.GT_ANY;
 
         // Determine which GregTech is loaded
-        // no GT loaded
         if(Loader.isModLoaded(mod.id)) {
             ModContainer m = Loader.instance().getIndexedModList().get(mod.id);
             if(isGTCE(m))
@@ -46,6 +47,8 @@ public class GTCompat {
                 gt = GTNE;
             else if(isGTCEu(m))
                 gt = GTCEu;
+            else if(isGTTJ(m))
+                gt = GTTJ;
             else // unsupported
                 gt = null;
         } else
@@ -90,5 +93,9 @@ public class GTCompat {
 
     public static boolean isGTNE(ModContainer m) {
         return GTNE.modName.equals(m.getMetadata().name);
+    }
+
+    public static boolean isGTTJ(ModContainer m) {
+        return GTTJ.modName.equals(m.getMetadata().name);
     }
 }


### PR DESCRIPTION
As of 1.18.2, GTCE TJ Fork is capable of being disambiguated from GTCEu.

This prevents a crash arising from misdetection as GTCEu, where things are referenced that do not exist (e.g. IGTTool).

Unfortunately, loading its MetaTool class at runtime doesn't seem to work, for reasons beyond my understanding (it is basically the same as GTCE and GTNE).

This means that getting the material a tool is made of won't work.